### PR TITLE
Plugin compatibility with Piwik 2.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - PLUGIN_NAME=SiteMigration
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
-    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-b16
+    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-rc1
     - secure: "MYN09GOHLHwhPl8+MXK4iDstpv4tVcE2mnAzoxOPCgwtkVGtoSKRwhjwsIWv74FxbwI82s4iSwy9/u8HDUYtPFtAqSiOTC/O26uIoUxn/I3Zgiw5D2IlryL8NJ1xzIjh2nsoSMzQ2ipoGq/DjGsO2nq/S9m7JosaPHoMfujYkWg="
     - secure: "dLzccYWjSBxe7SNph/mPIEDljLqCJgdnAEv7vpqLObLYGdYlnJbYbS/xmCQCwhjMeGDXduhwZfWqhEGwhZnoSDy6codXBevwI7MZXMQFWmkMbkdj5ukBMNP3YmbLAV3y5VlY0Y7L8Qu5JpWsI/IcALSLIHDvBLgztufx2DepNs4="
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - PLUGIN_NAME=SiteMigration
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
-    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-b15
+    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-b16
     - secure: "MYN09GOHLHwhPl8+MXK4iDstpv4tVcE2mnAzoxOPCgwtkVGtoSKRwhjwsIWv74FxbwI82s4iSwy9/u8HDUYtPFtAqSiOTC/O26uIoUxn/I3Zgiw5D2IlryL8NJ1xzIjh2nsoSMzQ2ipoGq/DjGsO2nq/S9m7JosaPHoMfujYkWg="
     - secure: "dLzccYWjSBxe7SNph/mPIEDljLqCJgdnAEv7vpqLObLYGdYlnJbYbS/xmCQCwhjMeGDXduhwZfWqhEGwhZnoSDy6codXBevwI7MZXMQFWmkMbkdj5ukBMNP3YmbLAV3y5VlY0Y7L8Qu5JpWsI/IcALSLIHDvBLgztufx2DepNs4="
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - PLUGIN_NAME=SiteMigration
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
-    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-rc1
+    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-rc3
     - secure: "MYN09GOHLHwhPl8+MXK4iDstpv4tVcE2mnAzoxOPCgwtkVGtoSKRwhjwsIWv74FxbwI82s4iSwy9/u8HDUYtPFtAqSiOTC/O26uIoUxn/I3Zgiw5D2IlryL8NJ1xzIjh2nsoSMzQ2ipoGq/DjGsO2nq/S9m7JosaPHoMfujYkWg="
     - secure: "dLzccYWjSBxe7SNph/mPIEDljLqCJgdnAEv7vpqLObLYGdYlnJbYbS/xmCQCwhjMeGDXduhwZfWqhEGwhZnoSDy6codXBevwI7MZXMQFWmkMbkdj5ukBMNP3YmbLAV3y5VlY0Y7L8Qu5JpWsI/IcALSLIHDvBLgztufx2DepNs4="
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - PLUGIN_NAME=SiteMigration
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
-    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-rc3
+    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-rc4
     - secure: "MYN09GOHLHwhPl8+MXK4iDstpv4tVcE2mnAzoxOPCgwtkVGtoSKRwhjwsIWv74FxbwI82s4iSwy9/u8HDUYtPFtAqSiOTC/O26uIoUxn/I3Zgiw5D2IlryL8NJ1xzIjh2nsoSMzQ2ipoGq/DjGsO2nq/S9m7JosaPHoMfujYkWg="
     - secure: "dLzccYWjSBxe7SNph/mPIEDljLqCJgdnAEv7vpqLObLYGdYlnJbYbS/xmCQCwhjMeGDXduhwZfWqhEGwhZnoSDy6codXBevwI7MZXMQFWmkMbkdj5ukBMNP3YmbLAV3y5VlY0Y7L8Qu5JpWsI/IcALSLIHDvBLgztufx2DepNs4="
   matrix:

--- a/plugin.json
+++ b/plugin.json
@@ -8,7 +8,7 @@
     "license": "GPL v3+",
     "license_page": "http://www.gnu.org/licenses/gpl.html",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.3.3",
         "piwik": ">=2.11.0"
     },
     "authors": [


### PR DESCRIPTION
DO NOT MERGE THIS PR MANUALLY.

This PR contains changes required to make SiteMigration compatible with Piwik 2.15.

It should be reviewed, then after all similar PRs are reviewed, they will be merged by a command.

* [x] Reviewed (make sure to confirm build is green).

Check the above box to let the command know this PR has been reviewed.
