### PR TITLE
Plugin compatibility with Piwik 2.16.0-b6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+group: legacy
+
 php:
   - 5.6
   - 5.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   global:
     - PLUGIN_NAME=SiteMigration
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
-    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-rc4
+    - PIWIK_LATEST_STABLE_TEST_TARGET=2.16.0-b6
     - secure: "MYN09GOHLHwhPl8+MXK4iDstpv4tVcE2mnAzoxOPCgwtkVGtoSKRwhjwsIWv74FxbwI82s4iSwy9/u8HDUYtPFtAqSiOTC/O26uIoUxn/I3Zgiw5D2IlryL8NJ1xzIjh2nsoSMzQ2ipoGq/DjGsO2nq/S9m7JosaPHoMfujYkWg="
     - secure: "dLzccYWjSBxe7SNph/mPIEDljLqCJgdnAEv7vpqLObLYGdYlnJbYbS/xmCQCwhjMeGDXduhwZfWqhEGwhZnoSDy6codXBevwI7MZXMQFWmkMbkdj5ukBMNP3YmbLAV3y5VlY0Y7L8Qu5JpWsI/IcALSLIHDvBLgztufx2DepNs4="
   matrix:


### PR DESCRIPTION
If you merge this PR manually and there is a version bump, you must remember to tag the new version.

This PR contains changes required to make SiteMigration compatible with Piwik 2.16.0-b6.

It should be reviewed, then after all similar PRs are reviewed, they will be merged by a command.

* [ ] Reviewed (make sure to confirm build is green).

Check the above box to let the command know this PR has been reviewed.