### PR TITLE
Add UNPROTECTED_ARTIFACTS=1 so artifacts are uploaded publicly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+group: legacy
+
 php:
   - 5.6
   - 5.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - PLUGIN_NAME=SiteMigration
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
     - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-rc4
+    - UNPROTECTED_ARTIFACTS=1
     - secure: "MYN09GOHLHwhPl8+MXK4iDstpv4tVcE2mnAzoxOPCgwtkVGtoSKRwhjwsIWv74FxbwI82s4iSwy9/u8HDUYtPFtAqSiOTC/O26uIoUxn/I3Zgiw5D2IlryL8NJ1xzIjh2nsoSMzQ2ipoGq/DjGsO2nq/S9m7JosaPHoMfujYkWg="
     - secure: "dLzccYWjSBxe7SNph/mPIEDljLqCJgdnAEv7vpqLObLYGdYlnJbYbS/xmCQCwhjMeGDXduhwZfWqhEGwhZnoSDy6codXBevwI7MZXMQFWmkMbkdj5ukBMNP3YmbLAV3y5VlY0Y7L8Qu5JpWsI/IcALSLIHDvBLgztufx2DepNs4="
   matrix:


### PR DESCRIPTION
When plugins are open source, artifacts can be uploaded publicly. as a result, developers don't need to specify login/password to the `tests:sync-ui-screenshots`

Refs https://github.com/piwik/piwik/issues/7761